### PR TITLE
Fix import error via capitalization

### DIFF
--- a/ReactTemplate/content/client/components/table/InlineEdit.tsx
+++ b/ReactTemplate/content/client/components/table/InlineEdit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import EditIcon from '@material-ui/icons/create';
+import EditIcon from '@material-ui/icons/Create';
 import TextField from '@material-ui/core/TextField';
 import grey from '@material-ui/core/colors/grey';
 


### PR DESCRIPTION
This was the only change I needed to make in order to successfully run this project, on Ubuntu v20.04 with either Node.js v14.9.2 or v18.1.0.

Otherwise, I get the following error:

`Can't resolve '@material-ui/icons/create' in '/home/coder/RiderProjects/dotNetify-react-template/ReactTemplate/content/client/components/table'`